### PR TITLE
build: clean up dependency types

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,15 @@
     "graphile-worker": "^0.5.0",
     "lodash": "^4.17.15",
     "mustache": "^4.0.1",
-    "pg": "^7.18.2",
     "runtypes": "^4.2.0",
     "tape": "^4.13.2",
     "tslib": "^1.9.3",
     "yaml": "^1.10.0",
     "yargs": "^15.3.1"
+  },
+  "peerDependencies": {
+    "@types/pg": ">=6.5 <9",
+    "pg": ">=6.5 <9"
   },
   "devDependencies": {
     "@types/chokidar": "^2.1.3",
@@ -77,6 +80,7 @@
     "fast-check": "^1.23.0",
     "jest": "^25.1.0",
     "jsverify": "^0.8.4",
+    "pg": "^7.18.2",
     "pg-connection-string": "^2.0.0",
     "prettier": "^1.19.1",
     "ts-jest": "^25.2.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "https://github.com/politics-rewired/pg-compose#readme",
   "dependencies": {
+    "@types/cryptr": "^4.0.1",
     "chokidar": "^3.3.1",
     "cosmiconfig": "^6.0.0",
     "cryptr": "^6.0.2",
@@ -55,7 +56,6 @@
   },
   "devDependencies": {
     "@types/chokidar": "^2.1.3",
-    "@types/cryptr": "^4.0.1",
     "@types/debug": "^4.1.2",
     "@types/faker": "^4.1.11",
     "@types/glob": "^7.1.1",


### PR DESCRIPTION
- The Crypt type is publicly exposed in our type definitions so we must ensure its type definitions are present.
- The pg dependency is publicly exposed but with a permissive version range.

See internal doc [Node Dependency Types](https://www.notion.so/Node-Dependency-Types-1508b3a84d2443b1a56e6c42c29f1fff).