### PR TITLE
fix: use configurable logger

### DIFF
--- a/src/cli-factory.ts
+++ b/src/cli-factory.ts
@@ -18,6 +18,7 @@ import {
   run as runWorker,
   TaskList,
 } from "./worker";
+import { DefaultLogger } from "./logger";
 
 // const submit = Query.prototype.submit;
 // Query.prototype.submit = function() {
@@ -65,6 +66,7 @@ const install = (taskList?: TaskList) => async (argv: CliOpts) => {
       schema: argv.schema,
       client,
       outFile: argv.out,
+      logger: DefaultLogger,
     };
 
     await installModule(m, runner, context);
@@ -99,6 +101,7 @@ const test = (taskList?: TaskList) => async (argv: CliOpts) => {
 
     const runContext: RunContextI | ToFileRunContextI = {
       schema: argv.schema,
+      logger: DefaultLogger,
       client,
     };
 
@@ -153,6 +156,7 @@ const run = (taskList?: TaskList) => async (argv: CliOpts) => {
 
   const runContext: RunContextI | ToFileRunContextI = {
     schema: argv.schema,
+    logger: DefaultLogger,
     client,
   };
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,23 @@
+import { LogFunctionFactory, Logger } from "graphile-worker";
+import { LogLevel, LogMeta } from "graphile-worker/dist/logger";
+
+const DefaultLogFactory: LogFunctionFactory = scope => (
+  level: LogLevel,
+  message: string,
+  meta?: LogMeta,
+) => {
+  switch (level) {
+    case LogLevel.DEBUG:
+      return console.debug(scope, message, meta);
+    case LogLevel.INFO:
+      return console.info(scope, message, meta);
+    case LogLevel.WARNING:
+      return console.warn(scope, message, meta);
+    case LogLevel.ERROR:
+      return console.error(scope, message, meta);
+    default:
+      return console.log(scope, message, meta);
+  }
+};
+
+export const DefaultLogger = new Logger(DefaultLogFactory);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,22 +1,22 @@
 import { LogFunctionFactory, Logger } from "graphile-worker";
-import { LogLevel, LogMeta } from "graphile-worker/dist/logger";
+import { LogLevel } from "graphile-worker/dist/logger";
 
 const DefaultLogFactory: LogFunctionFactory = scope => (
-  level: LogLevel,
-  message: string,
-  meta?: LogMeta,
+  level,
+  message,
+  meta,
 ) => {
   switch (level) {
     case LogLevel.DEBUG:
-      return console.debug(scope, message, meta);
+      return console.debug(message, { ...meta, ...scope });
     case LogLevel.INFO:
-      return console.info(scope, message, meta);
+      return console.info(message, { ...meta, ...scope });
     case LogLevel.WARNING:
-      return console.warn(scope, message, meta);
+      return console.warn(message, { ...meta, ...scope });
     case LogLevel.ERROR:
-      return console.error(scope, message, meta);
+      return console.error(message, { ...meta, ...scope });
     default:
-      return console.log(scope, message, meta);
+      return console.log(message, { ...meta, ...scope });
   }
 };
 

--- a/src/objects/test-helpers.ts
+++ b/src/objects/test-helpers.ts
@@ -1,6 +1,7 @@
 import { ObjectProvider, PgIdentifierI } from "./core";
 import { RunContextI } from "../runners";
 import { Pool } from "pg";
+import { DefaultLogger } from "../logger";
 
 const pool = new Pool();
 
@@ -45,7 +46,7 @@ export const checkIdempotencyOnSecondTable = async <ObjectType, OperationType>(
   const client = await pool.connect();
   await client.query("begin");
 
-  const context: RunContextI = { schema: "public", client };
+  const context: RunContextI = { schema: "public", client, logger: DefaultLogger };
 
   const beforeOperationList = await object.reconcile(before, undefined);
   const beforeStatements = beforeOperationList.map(o =>
@@ -90,7 +91,7 @@ export const checkIdempotencyAfterTransitions = async <
   const client = await pool.connect();
   await client.query("begin");
 
-  const context: RunContextI = { schema: "public", client };
+  const context: RunContextI = { schema: "public", client, logger: DefaultLogger };
 
   let runs = 0;
   let current: ObjectType | undefined = undefined;

--- a/src/runners/index.ts
+++ b/src/runners/index.ts
@@ -1,6 +1,8 @@
 import { Record, Partial, Union, Boolean, Static, String } from "runtypes";
+import { Logger } from "graphile-worker";
 import { PgIdentifier } from "../objects/core";
 import { ModuleOperationType } from "../objects/module";
+import { errToObj } from "../util";
 import { PoolClient } from "pg";
 import { promises as fs } from "fs";
 
@@ -25,10 +27,12 @@ export const ToFileRunContext = RunContext.And(
 
 export interface RunContextI extends Static<typeof RunContext> {
   client: PoolClient;
+  logger: Logger;
 }
 
 export interface ToFileRunContextI extends Static<typeof ToFileRunContext> {
   client: PoolClient;
+  logger: Logger;
 }
 
 type ToStatementFunction<OperationType> = (
@@ -53,11 +57,10 @@ export const directRunner: Runner = async (
     try {
       await context.client.query(statement);
     } catch (ex) {
-      console.error(
-        `Error running operation ${op.code}. Tried statement: \n\n${statement}\n\nGot error: `,
-        ex,
-      );
-      // process.exit(1);
+      context.logger.error(`Error running operation ${op.code}.`, {
+        statement,
+        error: errToObj(ex),
+      });
     }
   }
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,3 +42,14 @@ export const flattenKeyToProp = <T, U>(
 
 export const addOneIndexedOrder = <T>(arr: T[]): (T & { order: number })[] =>
   arr.map((t, idx) => Object.assign({}, t, { order: idx + 1 }));
+
+/**
+ * Convert an Error instance to a plain object, including all its non-iterable properties.
+ * @param err Error to convert to Object
+ * @returns Object representation of the error
+ */
+export const errToObj = (err: any): any =>
+  Object.getOwnPropertyNames(err).reduce<any>((acc, name) => {
+    acc[name] = err[name];
+    return acc;
+  }, {});

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -24,6 +24,7 @@ import { directRunner } from "../runners";
 import { Record, String, Dictionary, Unknown, Union } from "runtypes";
 import { fromPairs, toPairs } from "lodash";
 import { ModuleI } from "../objects/module/core";
+import { DefaultLogger } from "../logger";
 
 type PoolOrPoolClient = Pool | PoolClient;
 
@@ -130,6 +131,7 @@ export const runMigrations = async (
 
   await installModule(m, directRunner, {
     client,
+    logger: opts.logger ?? DefaultLogger,
     schema: "graphile_secrets",
   });
 


### PR DESCRIPTION
The `console.error()` produces very noisy logs in projects using `pg-compose`. This is more difficult examine and much more expensive to ingest in a log ingestion service.

A configurable `Logger` should be used throughout the project.