### PR TITLE
fix(set_secret): on conflict do nothing

### DIFF
--- a/src/worker/graphile-secrets.yaml
+++ b/src/worker/graphile-secrets.yaml
@@ -67,7 +67,7 @@ assertions:
 kind: Function
 name: set_secret
 arguments:
-  - name: ref
+  - name: secret_ref
     type: text
   - name: unencrypted_secret
     type: text
@@ -78,10 +78,11 @@ security: definer
 body: |
   begin
     insert into secrets (ref)
-    values (set_secret.ref);
+    values (set_secret.secret_ref)
+    on conflict (ref) do nothing;
 
     insert into unencrypted_secrets (ref, unencrypted_secret)
-    values (set_secret.ref, set_secret.unencrypted_secret);
+    values (set_secret.secret_ref, set_secret.unencrypted_secret);
 
-    return ref;
+    return secret_ref;
   end;


### PR DESCRIPTION
**Context**

A patch was made to `set_secret()` in a project that uses `pg-compose`. This patch added the `on conflict do nothing`, a necessary fix.

**This PR**

This PR updates the function to include that patch. It also changes the signature to match that of the downstream project.