### PR TITLE
test: fix flakey tests

### DIFF
--- a/src/objects/table/property.spec.ts
+++ b/src/objects/table/property.spec.ts
@@ -1,5 +1,4 @@
-import fc, { Arbitrary } from "fast-check";
-import { sample } from "lodash";
+import fc from "fast-check";
 
 import { PgIdentifier } from "../core";
 import { checkIdempotency } from "../test-helpers";
@@ -17,36 +16,40 @@ type RecordShape = {
   nullable: boolean;
 };
 
-type RecordTypeDefaultArbitrary = {
-  [A in keyof Pick<RecordShape, "type" | "default">]: Arbitrary<RecordShape[A]>;
-};
-
-const pairings: RecordTypeDefaultArbitrary[] = [
-  {
-    type: fc.constant("text"),
-    default: fc.oneof(fc.constant(undefined), fc.asciiString()),
-  },
-  {
-    type: fc.constant("numeric"),
-    default: fc.oneof(fc.constant(undefined), fc.float()),
-  },
-  {
-    type: fc.constant("integer"),
-    default: fc.oneof(fc.constant(undefined), fc.integer()),
-  },
-  {
-    type: fc.constant("timestamp"),
-    default: fc.oneof(fc.constant(undefined), fc.integer()),
-  },
-];
-
-const ColumnArbitrary = fc
-  .record<RecordShape>({
-    name: PgIdentifierArbitrary,
-    nullable: fc.boolean(),
-    ...sample(pairings)!,
-  })
-  .filter(Column.guard);
+const ColumnArbitrary = fc.oneof(
+  fc
+    .record<RecordShape>({
+      name: PgIdentifierArbitrary,
+      nullable: fc.boolean(),
+      type: fc.constant("text"),
+      default: fc.oneof(fc.constant(undefined), fc.asciiString()),
+    })
+    .filter(Column.guard),
+  fc
+    .record<RecordShape>({
+      name: PgIdentifierArbitrary,
+      nullable: fc.boolean(),
+      type: fc.constant("numeric"),
+      default: fc.oneof(fc.constant(undefined), fc.float()),
+    })
+    .filter(Column.guard),
+  fc
+    .record<RecordShape>({
+      name: PgIdentifierArbitrary,
+      nullable: fc.boolean(),
+      type: fc.constant("integer"),
+      default: fc.oneof(fc.constant(undefined), fc.integer()),
+    })
+    .filter(Column.guard),
+  fc
+    .record<RecordShape>({
+      name: PgIdentifierArbitrary,
+      nullable: fc.boolean(),
+      type: fc.constant("timestamp"),
+      default: fc.oneof(fc.constant(undefined), fc.integer()),
+    })
+    .filter(Column.guard),
+);
 
 const TableArbitary = fc.record({
   kind: fc.constant("Table"),

--- a/src/objects/table/property.spec.ts
+++ b/src/objects/table/property.spec.ts
@@ -51,7 +51,9 @@ const ColumnArbitrary = fc
 const TableArbitary = fc.record({
   kind: fc.constant("Table"),
   name: PgIdentifierArbitrary,
-  columns: fc.array(ColumnArbitrary),
+  columns: fc.uniqueArray(ColumnArbitrary, {
+    selector: c => c.name,
+  }),
   rls_enabled: fc.boolean(),
 });
 

--- a/src/objects/table/property.spec.ts
+++ b/src/objects/table/property.spec.ts
@@ -17,36 +17,76 @@ type RecordShape = {
 };
 
 const ColumnArbitrary = fc.oneof(
+  // text
   fc
     .record<RecordShape>({
       name: PgIdentifierArbitrary,
-      nullable: fc.boolean(),
+      nullable: fc.constant(true),
       type: fc.constant("text"),
       default: fc.oneof(fc.constant(undefined), fc.asciiString()),
     })
     .filter(Column.guard),
+  // NOT NULL text
   fc
     .record<RecordShape>({
       name: PgIdentifierArbitrary,
-      nullable: fc.boolean(),
+      nullable: fc.constant(false),
+      type: fc.constant("text"),
+      default: fc.oneof(fc.asciiString()),
+    })
+    .filter(Column.guard),
+  // numeric
+  fc
+    .record<RecordShape>({
+      name: PgIdentifierArbitrary,
+      nullable: fc.constant(true),
       type: fc.constant("numeric"),
       default: fc.oneof(fc.constant(undefined), fc.float()),
     })
     .filter(Column.guard),
+  // NOT NULL numeric
   fc
     .record<RecordShape>({
       name: PgIdentifierArbitrary,
-      nullable: fc.boolean(),
+      nullable: fc.constant(false),
+      type: fc.constant("numeric"),
+      default: fc.oneof(fc.float()),
+    })
+    .filter(Column.guard),
+  // integer
+  fc
+    .record<RecordShape>({
+      name: PgIdentifierArbitrary,
+      nullable: fc.constant(true),
       type: fc.constant("integer"),
       default: fc.oneof(fc.constant(undefined), fc.integer()),
     })
     .filter(Column.guard),
+  // NOT NULL integer
   fc
     .record<RecordShape>({
       name: PgIdentifierArbitrary,
-      nullable: fc.boolean(),
+      nullable: fc.constant(false),
+      type: fc.constant("integer"),
+      default: fc.oneof(fc.integer()),
+    })
+    .filter(Column.guard),
+  // timestamp
+  fc
+    .record<RecordShape>({
+      name: PgIdentifierArbitrary,
+      nullable: fc.constant(true),
       type: fc.constant("timestamp"),
       default: fc.oneof(fc.constant(undefined), fc.integer()),
+    })
+    .filter(Column.guard),
+  // NOT NULL timestamp
+  fc
+    .record<RecordShape>({
+      name: PgIdentifierArbitrary,
+      nullable: fc.constant(false),
+      type: fc.constant("timestamp"),
+      default: fc.oneof(fc.integer()),
     })
     .filter(Column.guard),
 );

--- a/src/objects/table/property.spec.ts
+++ b/src/objects/table/property.spec.ts
@@ -95,6 +95,7 @@ const TableArbitary = fc.record({
   kind: fc.constant("Table"),
   name: PgIdentifierArbitrary,
   columns: fc.uniqueArray(ColumnArbitrary, {
+    maxLength: 2,
     selector: c => c.name,
   }),
   rls_enabled: fc.boolean(),


### PR DESCRIPTION
There are still three problems:
1. `sample` runs once at startup, not for each Arbitrary. Thus all column types will be the same for a given test run
2. Unique column names are not guaranteed
3. A default of `null` was a possibility for non-nullable columns